### PR TITLE
[WIP] Add RAY.BATCH_CLEAN command in redis module.

### DIFF
--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -117,6 +117,8 @@ AsyncGcsClient::AsyncGcsClient(const std::string &address, int port,
   task_lease_table_.reset(new TaskLeaseTable(shard_contexts_, this));
   heartbeat_table_.reset(new HeartbeatTable(shard_contexts_, this));
   profile_table_.reset(new ProfileTable(shard_contexts_, this));
+  batch_info_table_.reset(new BatchInfoTable(shard_contexts_, this));
+  batch_object_table_.reset(new BatchObjectTable(shard_contexts_, this));
   command_type_ = command_type;
 
   // TODO(swang): Call the client table's Connect() method here. To do this,
@@ -206,6 +208,10 @@ ErrorTable &AsyncGcsClient::error_table() { return *error_table_; }
 DriverTable &AsyncGcsClient::driver_table() { return *driver_table_; }
 
 ProfileTable &AsyncGcsClient::profile_table() { return *profile_table_; }
+
+BatchInfoTable &AsyncGcsClient::batch_info_table() { return *batch_info_table_; }
+
+BatchObjectTable &AsyncGcsClient::batch_object_table() { return *batch_object_table_; }
 
 }  // namespace gcs
 

--- a/src/ray/gcs/client.cc
+++ b/src/ray/gcs/client.cc
@@ -117,8 +117,9 @@ AsyncGcsClient::AsyncGcsClient(const std::string &address, int port,
   task_lease_table_.reset(new TaskLeaseTable(shard_contexts_, this));
   heartbeat_table_.reset(new HeartbeatTable(shard_contexts_, this));
   profile_table_.reset(new ProfileTable(shard_contexts_, this));
-  batch_info_table_.reset(new BatchInfoTable(shard_contexts_, this));
-  batch_object_table_.reset(new BatchObjectTable(shard_contexts_, this));
+  batch_parent_table_.reset(new BatchParentTable(shard_contexts_, this));
+  batch_child_table_.reset(new BatchChildTable(shard_contexts_, this));
+  batch_resource_table_.reset(new BatchResourceTable(shard_contexts_, this));
   command_type_ = command_type;
 
   // TODO(swang): Call the client table's Connect() method here. To do this,
@@ -209,9 +210,13 @@ DriverTable &AsyncGcsClient::driver_table() { return *driver_table_; }
 
 ProfileTable &AsyncGcsClient::profile_table() { return *profile_table_; }
 
-BatchInfoTable &AsyncGcsClient::batch_info_table() { return *batch_info_table_; }
+BatchParentTable &AsyncGcsClient::batch_parent_table() { return *batch_parent_table_; }
 
-BatchObjectTable &AsyncGcsClient::batch_object_table() { return *batch_object_table_; }
+BatchChildTable &AsyncGcsClient::batch_child_table() { return *batch_child_table_; }
+
+BatchResourceTable &AsyncGcsClient::batch_resource_table() {
+  return *batch_resource_table_;
+}
 
 }  // namespace gcs
 

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -64,8 +64,9 @@ class RAY_EXPORT AsyncGcsClient {
   ErrorTable &error_table();
   DriverTable &driver_table();
   ProfileTable &profile_table();
-  BatchInfoTable &batch_info_table();
-  BatchObjectTable &batch_object_table();
+  BatchParentTable &batch_parent_table();
+  BatchChildTable &batch_child_table();
+  BatchResourceTable &batch_resource_table();
 
   // We also need something to export generic code to run on workers from the
   // driver (to set the PYTHONPATH)
@@ -91,8 +92,9 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<ErrorTable> error_table_;
   std::unique_ptr<ProfileTable> profile_table_;
   std::unique_ptr<ClientTable> client_table_;
-  std::unique_ptr<BatchInfoTable> batch_info_table_;
-  std::unique_ptr<BatchObjectTable> batch_object_table_;
+  std::unique_ptr<BatchChildTable> batch_child_table_;
+  std::unique_ptr<BatchParentTable> batch_parent_table_;
+  std::unique_ptr<BatchResourceTable> batch_resource_table_;
   // The following contexts write to the data shard
   std::vector<std::shared_ptr<RedisContext>> shard_contexts_;
   std::vector<std::unique_ptr<RedisAsioClient>> shard_asio_async_clients_;

--- a/src/ray/gcs/client.h
+++ b/src/ray/gcs/client.h
@@ -64,6 +64,8 @@ class RAY_EXPORT AsyncGcsClient {
   ErrorTable &error_table();
   DriverTable &driver_table();
   ProfileTable &profile_table();
+  BatchInfoTable &batch_info_table();
+  BatchObjectTable &batch_object_table();
 
   // We also need something to export generic code to run on workers from the
   // driver (to set the PYTHONPATH)
@@ -89,6 +91,8 @@ class RAY_EXPORT AsyncGcsClient {
   std::unique_ptr<ErrorTable> error_table_;
   std::unique_ptr<ProfileTable> profile_table_;
   std::unique_ptr<ClientTable> client_table_;
+  std::unique_ptr<BatchInfoTable> batch_info_table_;
+  std::unique_ptr<BatchObjectTable> batch_object_table_;
   // The following contexts write to the data shard
   std::vector<std::shared_ptr<RedisContext>> shard_contexts_;
   std::vector<std::unique_ptr<RedisAsioClient>> shard_asio_async_clients_;

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -19,6 +19,8 @@ enum TablePrefix:int {
   DRIVER,
   PROFILE,
   TASK_LEASE,
+  BATCH_INFO,
+  BATCH_OBJECTS,
 }
 
 // The channel that Add operations to the Table should be published on, if any.
@@ -33,6 +35,7 @@ enum TablePubsub:int {
   ERROR_INFO,
   TASK_LEASE,
   DRIVER,
+  BATCH,
 }
 
 table GcsTableEntry {
@@ -216,4 +219,20 @@ table DriverTableData {
   driver_id: string;
   // Whether it's dead.
   is_dead: bool;
+}
+
+// One batch object which will be deleted when batch finishes.
+// This object will be added to a BATCH_OBJECT_TABLE.
+table BatchObjectData {
+  // The object prefix to mark the object type: object/function/task/actor.
+  prefix: TablePrefix;
+  // The correpending id.
+  object_id: string;
+}
+
+table BatchInfoData {
+  // The parent batch id of this batch. If no parent, this will be nilId.
+  parent_id: string;
+  // The list of child batch ids.
+  child_ids: [string];
 }

--- a/src/ray/gcs/format/gcs.fbs
+++ b/src/ray/gcs/format/gcs.fbs
@@ -19,8 +19,9 @@ enum TablePrefix:int {
   DRIVER,
   PROFILE,
   TASK_LEASE,
-  BATCH_INFO,
-  BATCH_OBJECTS,
+  BATCH_PARENT,
+  BATCH_CHILD,
+  BATCH_RESOURCE,
 }
 
 // The channel that Add operations to the Table should be published on, if any.
@@ -35,7 +36,7 @@ enum TablePubsub:int {
   ERROR_INFO,
   TASK_LEASE,
   DRIVER,
-  BATCH,
+  BATCH_CLEAN,
 }
 
 table GcsTableEntry {
@@ -223,16 +224,15 @@ table DriverTableData {
 
 // One batch object which will be deleted when batch finishes.
 // This object will be added to a BATCH_OBJECT_TABLE.
-table BatchObjectData {
+table BatchResourceData {
   // The object prefix to mark the object type: object/function/task/actor.
   prefix: TablePrefix;
   // The correpending id.
   object_id: string;
 }
 
-table BatchInfoData {
-  // The parent batch id of this batch. If no parent, this will be nilId.
-  parent_id: string;
-  // The list of child batch ids.
-  child_ids: [string];
+table BatchIdData {
+  // The batch id representing the Parent Batch Id in BatchParentTable,
+  // and the Child Id in BatchChildTable.
+  batch_id: string;
 }

--- a/src/ray/gcs/tables.cc
+++ b/src/ray/gcs/tables.cc
@@ -435,6 +435,11 @@ const ClientTableDataT &ClientTable::GetClient(const ClientID &client_id) const 
 
 const std::unordered_map<ClientID, ClientTableDataT> &ClientTable::GetAllClients() const {
   return client_cache_;
+
+Status BatchObjectTable::CleanBatchObjects(const BatchID &batch_id) {
+  std::vector<uint8_t> nil;
+  return context_->RunAsync("RAY.BATCH_CLEAN", batch_id, nil.data(), nil.size(), prefix_,
+                            pubsub_channel_, nullptr);
 }
 
 template class Log<ObjectID, ObjectTableData>;
@@ -449,6 +454,8 @@ template class Log<JobID, ErrorTableData>;
 template class Log<UniqueID, ClientTableData>;
 template class Log<JobID, DriverTableData>;
 template class Log<UniqueID, ProfileTableData>;
+template class Log<BatchID, BatchObjectData>;
+template class Table<BatchID, BatchInfoData>;
 
 }  // namespace gcs
 

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -379,6 +379,26 @@ class ActorTable : public Log<ActorID, ActorTableData> {
   }
 };
 
+class BatchObjectTable : public Log<BatchID, BatchObjectData> {
+ public:
+  BatchObjectTable(const std::shared_ptr<RedisContext> &context, AsyncGcsClient *client)
+      : Log(context, client) {
+    pubsub_channel_ = TablePubsub::NO_PUBLISH;
+    prefix_ = TablePrefix::BATCH_OBJECTS;
+  }
+
+  Status CleanBatchObjects(const BatchID &batch_id);
+};
+
+class BatchInfoTable : public Table<BatchID, BatchInfoData> {
+ public:
+  BatchInfoTable(const std::shared_ptr<RedisContext> &context, AsyncGcsClient *client)
+      : Table(context, client) {
+    pubsub_channel_ = TablePubsub::BATCH;
+    prefix_ = TablePrefix::BATCH_INFO;
+  }
+};
+
 class TaskReconstructionLog : public Log<TaskID, TaskReconstructionData> {
  public:
   TaskReconstructionLog(const std::vector<std::shared_ptr<RedisContext>> &contexts,

--- a/src/ray/id.h
+++ b/src/ray/id.h
@@ -50,6 +50,7 @@ typedef UniqueID FunctionID;
 typedef UniqueID ClassID;
 typedef UniqueID ActorID;
 typedef UniqueID ActorHandleID;
+typedef UniqueID BatchID;
 typedef UniqueID WorkerID;
 typedef UniqueID DriverID;
 typedef UniqueID ConfigID;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
[WIP] for batch.
1. **Completed**: Add the Redis command `RAY.BATCH_CLEAN` Redis module.
2. **Completed**: One table named `BatchResouceTable` is used to store all the resource ids of objects/actor/task, etc, under this batch. When `RAY.BATCH_CLEAN` is called, Redis will clean the corresponding entries of the resource ids in GCS and the batch resource table itself. 
3. **Completed**: Node Manager will subscribe the batch clean message. When `RAY.BATCH_CLEAN` is called, Node Managers will receive a message containing all the resource ids in the `BatchResouceTable` and Node Manager can call the Free Function (implemented in this [PR](https://github.com/ant-tech-alliance/ray/pull/52/files)) of Object Manager to release the objects in Plasma Store. This Free request to Object Manager won't spread since each Node Manager has subscribed `RAY.BATCH_CLEAN`.
4. **On-going**: Implement the script to support the batch concept.
5. **On-going**: The other tables are `BatchParentTable` and `BatchChildTable` as discussed in PRD. It is no used in current code change.

This is a draft implementation. Please point out what are concerned. 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
