### PR TITLE
[review only][direct call] avoid hang on `Get()` for evicted task return objects

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -28,7 +28,7 @@ CoreWorker::CoreWorker(
   InitializeTaskSubmitters();
 
   object_interface_ = std::unique_ptr<CoreWorkerObjectInterface>(
-      new CoreWorkerObjectInterface(worker_context_, store_providers_));
+      new CoreWorkerObjectInterface(worker_context_, store_providers_, task_submitters_));
   task_interface_ = std::unique_ptr<CoreWorkerTaskInterface>(new CoreWorkerTaskInterface(
       worker_context_, task_submitters_));
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1,5 +1,10 @@
 #include "ray/core_worker/core_worker.h"
 #include "ray/core_worker/context.h"
+#include "ray/core_worker/store_provider/local_plasma_provider.h"
+#include "ray/core_worker/store_provider/memory_store_provider.h"
+#include "ray/core_worker/store_provider/plasma_store_provider.h"
+#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/raylet_transport.h"
 
 namespace ray {
 
@@ -10,6 +15,7 @@ CoreWorker::CoreWorker(
     const CoreWorkerTaskExecutionInterface::TaskExecutor &execution_callback)
     : worker_type_(worker_type),
       language_(language),
+      store_socket_(store_socket),
       raylet_socket_(raylet_socket),
       worker_context_(worker_type, job_id),
       io_work_(io_service_) {
@@ -18,17 +24,20 @@ CoreWorker::CoreWorker(
       std::unique_ptr<gcs::RedisGcsClient>(new gcs::RedisGcsClient(gcs_options));
   RAY_CHECK_OK(gcs_client_->Connect(io_service_));
 
+  InitializeStoreProviders();
+  InitializeTaskSubmitters();
+
   object_interface_ = std::unique_ptr<CoreWorkerObjectInterface>(
-      new CoreWorkerObjectInterface(worker_context_, raylet_client_, store_socket));
+      new CoreWorkerObjectInterface(worker_context_, store_providers_));
   task_interface_ = std::unique_ptr<CoreWorkerTaskInterface>(new CoreWorkerTaskInterface(
-      worker_context_, raylet_client_, *object_interface_, io_service_, *gcs_client_));
+      worker_context_, task_submitters_));
 
   int rpc_server_port = 0;
   if (worker_type_ == WorkerType::WORKER) {
     RAY_CHECK(execution_callback != nullptr);
     task_execution_interface_ = std::unique_ptr<CoreWorkerTaskExecutionInterface>(
         new CoreWorkerTaskExecutionInterface(worker_context_, raylet_client_,
-                                             *object_interface_, execution_callback));
+                                             store_providers_, execution_callback));
     rpc_server_port = task_execution_interface_->worker_server_.GetPort();
   }
   // TODO(zhijunfu): currently RayletClient would crash in its constructor if it cannot
@@ -56,5 +65,51 @@ CoreWorker::~CoreWorker() {
 }
 
 void CoreWorker::StartIOService() { io_service_.run(); }
+
+void CoreWorker::InitializeStoreProviders() {
+  memory_store_ = std::make_shared<CoreWorkerMemoryStore>();
+
+  store_providers_.emplace(StoreProviderType::LOCAL_PLASMA,
+      CreateStoreProvider(StoreProviderType::LOCAL_PLASMA));
+  store_providers_.emplace(StoreProviderType::PLASMA,
+      CreateStoreProvider(StoreProviderType::PLASMA));
+  store_providers_.emplace(StoreProviderType::MEMORY,
+      CreateStoreProvider(StoreProviderType::MEMORY));
+}
+
+std::unique_ptr<CoreWorkerStoreProvider>
+CoreWorker::CreateStoreProvider(StoreProviderType type) {
+  switch (type) {
+  case StoreProviderType::LOCAL_PLASMA:
+    return std::unique_ptr<CoreWorkerStoreProvider>(
+        new CoreWorkerLocalPlasmaStoreProvider(store_socket_));
+    break;
+  case StoreProviderType::PLASMA:
+    return std::unique_ptr<CoreWorkerStoreProvider>(new CoreWorkerPlasmaStoreProvider(
+        store_socket_, raylet_client_));
+    break;
+  case StoreProviderType::MEMORY:
+    return std::unique_ptr<CoreWorkerStoreProvider>(
+        new CoreWorkerMemoryStoreProvider(memory_store_));
+    break;
+  default:
+    // Should never reach here.
+    RAY_LOG(FATAL) << "unknown store provider type " << static_cast<int>(type);
+    return nullptr;
+  }
+}
+
+void CoreWorker::InitializeTaskSubmitters() {
+  // Add all task submitters.
+  task_submitters_.emplace(TaskTransportType::RAYLET,
+                           std::unique_ptr<CoreWorkerRayletTaskSubmitter>(
+                               new CoreWorkerRayletTaskSubmitter(raylet_client_)));
+  task_submitters_.emplace(
+      TaskTransportType::DIRECT_ACTOR,
+      std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(
+          new CoreWorkerDirectActorTaskSubmitter(
+              io_service_, *gcs_client_,
+              CreateStoreProvider(StoreProviderType::MEMORY))));
+}
 
 }  // namespace ray

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -10,6 +10,9 @@
 #include "ray/gcs/redis_gcs_client.h"
 #include "ray/raylet/raylet_client.h"
 
+#include "ray/core_worker/store_provider/store_provider.h"
+#include "ray/core_worker/transport/transport.h"
+
 namespace ray {
 
 /// The root class that contains all the core and language-independent functionalities
@@ -58,11 +61,19 @@ class CoreWorker {
  private:
   void StartIOService();
 
+  void InitializeStoreProviders();
+  void InitializeTaskSubmitters();
+
+  std::unique_ptr<CoreWorkerStoreProvider> CreateStoreProvider(StoreProviderType type);
+
   /// Type of this worker.
   const WorkerType worker_type_;
 
   /// Language of this worker.
   const Language language_;
+
+  /// plasma store socket name.
+  const std::string store_socket_;
 
   /// raylet socket name.
   const std::string raylet_socket_;
@@ -84,6 +95,21 @@ class CoreWorker {
 
   /// GCS client.
   std::unique_ptr<gcs::RedisGcsClient> gcs_client_;
+
+  /// In-memory store for return objects. This is used for `MEMORY` store provider.
+  std::shared_ptr<CoreWorkerMemoryStore> memory_store_;
+
+  /// All the store providers supported.
+  EnumUnorderedMap<StoreProviderType, std::unique_ptr<CoreWorkerStoreProvider>>
+      store_providers_;
+
+  /// All the task submitters supported.
+  EnumUnorderedMap<TaskTransportType, std::unique_ptr<CoreWorkerTaskSubmitter>>
+      task_submitters_;
+
+  /// All the task task receivers supported.
+  EnumUnorderedMap<TaskTransportType, std::unique_ptr<CoreWorkerTaskReceiver>>
+      task_receivers_;
 
   /// The `CoreWorkerTaskInterface` instance.
   std::unique_ptr<CoreWorkerTaskInterface> task_interface_;

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -19,8 +19,7 @@ class CoreWorkerMemoryStore;
 class CoreWorkerObjectInterface {
  public:
   CoreWorkerObjectInterface(WorkerContext &worker_context,
-                            std::unique_ptr<RayletClient> &raylet_client,
-                            const std::string &store_socket);
+                            CoreWorkerStoreProviderMap &store_providers);
 
   /// Put an object into object store.
   ///
@@ -120,18 +119,9 @@ class CoreWorkerObjectInterface {
 
   /// Reference to the parent CoreWorker's context.
   WorkerContext &worker_context_;
-  /// Reference to the parent CoreWorker's raylet client.
-  std::unique_ptr<RayletClient> &raylet_client_;
-
-  /// Store socket name.
-  std::string store_socket_;
-
-  /// In-memory store for return objects. This is used for `MEMORY` store provider.
-  std::shared_ptr<CoreWorkerMemoryStore> memory_store_;
 
   /// All the store providers supported.
-  EnumUnorderedMap<StoreProviderType, std::unique_ptr<CoreWorkerStoreProvider>>
-      store_providers_;
+  CoreWorkerStoreProviderMap &store_providers_;
 
   friend class CoreWorkerTaskInterface;
 

--- a/src/ray/core_worker/object_interface.h
+++ b/src/ray/core_worker/object_interface.h
@@ -8,6 +8,7 @@
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/store_provider/store_provider.h"
+#include "ray/core_worker/transport/transport.h"
 
 namespace ray {
 
@@ -19,7 +20,8 @@ class CoreWorkerMemoryStore;
 class CoreWorkerObjectInterface {
  public:
   CoreWorkerObjectInterface(WorkerContext &worker_context,
-                            CoreWorkerStoreProviderMap &store_providers);
+                            CoreWorkerStoreProviderMap &store_providers,
+                            const CoreWorkerTaskSubmitterMap &task_submitters);
 
   /// Put an object into object store.
   ///
@@ -122,6 +124,8 @@ class CoreWorkerObjectInterface {
 
   /// All the store providers supported.
   CoreWorkerStoreProviderMap &store_providers_;
+
+  const CoreWorkerTaskSubmitterMap &task_submitters_;
 
   friend class CoreWorkerTaskInterface;
 

--- a/src/ray/core_worker/store_provider/memory_store_provider.cc
+++ b/src/ray/core_worker/store_provider/memory_store_provider.cc
@@ -18,7 +18,10 @@ CoreWorkerMemoryStoreProvider::CoreWorkerMemoryStoreProvider(
 
 Status CoreWorkerMemoryStoreProvider::Put(const RayObject &object,
                                           const ObjectID &object_id) {
-  return store_->Put(object_id, object);
+  auto status = store_->Put(object_id, object);
+  // TODO(zhijunfu): check for duplicate object ids has been done
+  // in the asio rpc changes.
+  return Status::OK();
 }
 
 Status CoreWorkerMemoryStoreProvider::Get(

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -110,6 +110,9 @@ class CoreWorkerStoreProvider {
                         bool delete_creating_tasks = false) = 0;
 };
 
+using CoreWorkerStoreProviderMap =
+    EnumUnorderedMap<StoreProviderType, std::unique_ptr<CoreWorkerStoreProvider>>;
+
 }  // namespace ray
 
 #endif  // RAY_CORE_WORKER_STORE_PROVIDER_H

--- a/src/ray/core_worker/store_provider/store_provider.h
+++ b/src/ray/core_worker/store_provider/store_provider.h
@@ -5,6 +5,7 @@
 #include "ray/common/id.h"
 #include "ray/common/status.h"
 #include "ray/core_worker/common.h"
+#include "ray/common/ray_config.h"
 
 namespace ray {
 
@@ -48,6 +49,25 @@ class RayObject {
 
   /// Whether this object has metadata.
   bool HasMetadata() const { return metadata_ != nullptr && metadata_->Size() > 0; }
+
+  /// Whether this object represents an exception object.
+  bool IsException() const {
+    if (!HasMetadata()) {
+      return false;
+    }
+
+    // TODO (kfstorm): metadata should be structured.
+    const std::string metadata(reinterpret_cast<const char *>(GetMetadata()->Data()),
+                               GetMetadata()->Size());
+    const auto error_type_descriptor = ray::rpc::ErrorType_descriptor();
+    for (int i = 0; i < error_type_descriptor->value_count(); i++) {
+      const auto error_type_number = error_type_descriptor->value(i)->number();
+      if (metadata == std::to_string(error_type_number)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
  private:
   /// Data of the ray object.
@@ -108,6 +128,39 @@ class CoreWorkerStoreProvider {
   /// \return Status.
   virtual Status Delete(const std::vector<ObjectID> &object_ids, bool local_only = true,
                         bool delete_creating_tasks = false) = 0;
+
+  /// Print a warning if we've attempted too many times, but some objects are still
+  /// unavailable.
+  ///
+  /// \param[in] num_attemps The number of attempted times.
+  /// \param[in] unready The unready objects.
+  static void WarnIfAttemptedTooManyTimes(int num_attempts,
+                                          const std::unordered_set<ObjectID> &unready) {
+    if (num_attempts % RayConfig::instance().object_store_get_warn_per_num_attempts() ==
+        0) {
+      std::ostringstream oss;
+      size_t printed = 0;
+      for (auto &entry : unready) {
+        if (printed >=
+            RayConfig::instance().object_store_get_max_ids_to_print_in_warning()) {
+          break;
+        }
+        if (printed > 0) {
+          oss << ", ";
+        }
+        oss << entry.Hex();
+      }
+      if (printed < unready.size()) {
+        oss << ", etc";
+      }
+      RAY_LOG(WARNING)
+          << "Attempted " << num_attempts << " times to reconstruct objects, but "
+          << "some objects are still unavailable. If this message continues to print,"
+          << " it may indicate that object's creating task is hanging, or something wrong"
+          << " happened in raylet backend. " << unready.size()
+          << " object(s) pending: " << oss.str() << ".";
+    }
+  }
 };
 
 using CoreWorkerStoreProviderMap =

--- a/src/ray/core_worker/task_execution.h
+++ b/src/ray/core_worker/task_execution.h
@@ -36,7 +36,7 @@ class CoreWorkerTaskExecutionInterface {
 
   CoreWorkerTaskExecutionInterface(WorkerContext &worker_context,
                                    std::unique_ptr<RayletClient> &raylet_client,
-                                   CoreWorkerObjectInterface &object_interface,
+                                   CoreWorkerStoreProviderMap &store_providers,
                                    const TaskExecutor &executor);
 
   /// Start receiving and executing tasks.
@@ -69,8 +69,9 @@ class CoreWorkerTaskExecutionInterface {
 
   /// Reference to the parent CoreWorker's context.
   WorkerContext &worker_context_;
-  /// Reference to the parent CoreWorker's objects interface.
-  CoreWorkerObjectInterface &object_interface_;
+
+
+  CoreWorkerStoreProviderMap &store_providers_;
 
   // Task execution callback.
   TaskExecutor execution_callback_;

--- a/src/ray/core_worker/task_interface.cc
+++ b/src/ray/core_worker/task_interface.cc
@@ -2,8 +2,7 @@
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/core_worker.h"
 #include "ray/core_worker/task_interface.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
-#include "ray/core_worker/transport/raylet_transport.h"
+
 
 namespace ray {
 
@@ -99,20 +98,10 @@ std::vector<ray::ActorHandleID> ActorHandle::NewActorHandles() const {
 void ActorHandle::ClearNewActorHandles() { new_actor_handles_.clear(); }
 
 CoreWorkerTaskInterface::CoreWorkerTaskInterface(
-    WorkerContext &worker_context, std::unique_ptr<RayletClient> &raylet_client,
-    CoreWorkerObjectInterface &object_interface, boost::asio::io_service &io_service,
-    gcs::RedisGcsClient &gcs_client)
-    : worker_context_(worker_context) {
-  task_submitters_.emplace(TaskTransportType::RAYLET,
-                           std::unique_ptr<CoreWorkerRayletTaskSubmitter>(
-                               new CoreWorkerRayletTaskSubmitter(raylet_client)));
-  task_submitters_.emplace(
-      TaskTransportType::DIRECT_ACTOR,
-      std::unique_ptr<CoreWorkerDirectActorTaskSubmitter>(
-          new CoreWorkerDirectActorTaskSubmitter(
-              io_service, gcs_client,
-              object_interface.CreateStoreProvider(StoreProviderType::MEMORY))));
-}
+    WorkerContext &worker_context,
+    CoreWorkerTaskSubmitterMap &task_submitters)
+    : worker_context_(worker_context),
+      task_submitters_(task_submitters) {}
 
 void CoreWorkerTaskInterface::BuildCommonTaskSpec(
     TaskSpecBuilder &builder, const TaskID &task_id, const int task_index,

--- a/src/ray/core_worker/task_interface.h
+++ b/src/ray/core_worker/task_interface.h
@@ -130,10 +130,7 @@ class ActorHandle {
 class CoreWorkerTaskInterface {
  public:
   CoreWorkerTaskInterface(WorkerContext &worker_context,
-                          std::unique_ptr<RayletClient> &raylet_client,
-                          CoreWorkerObjectInterface &object_interface,
-                          boost::asio::io_service &io_service,
-                          gcs::RedisGcsClient &gcs_client);
+      CoreWorkerTaskSubmitterMap &task_submitters);
 
   /// Submit a normal task.
   ///
@@ -195,8 +192,7 @@ class CoreWorkerTaskInterface {
   WorkerContext &worker_context_;
 
   /// All the task submitters supported.
-  EnumUnorderedMap<TaskTransportType, std::unique_ptr<CoreWorkerTaskSubmitter>>
-      task_submitters_;
+  CoreWorkerTaskSubmitterMap &task_submitters_;
 
   friend class CoreWorkerTest;
 };

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -299,6 +299,21 @@ void CoreWorkerTest::TestActorTask(
       ASSERT_EQ(memcmp(results[0]->GetData()->Data() + buffer1->Size(), buffer2->Data(),
                        buffer2->Size()),
                 0);
+
+      if (is_direct_call) {
+        results.clear();
+        RAY_CHECK_OK(driver.Objects().Get(return_ids, -1, &results));
+        ASSERT_EQ(results.size(), 1);
+
+        // For memory store the objects are removed after the first `Get`,
+        // so the second one should return `OBJECT_UNRECONSTRUCTABLE`.
+        ASSERT_TRUE(results[0]->HasMetadata());
+        // Verify if this is the desired error.
+        std::string meta =
+            std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE));
+        ASSERT_TRUE(memcmp(results[0]->GetMetadata()->Data(), meta.data(), meta.size()) ==
+                    0);
+      }                 
     }
   }
 
@@ -340,7 +355,7 @@ void CoreWorkerTest::TestActorTask(
     ASSERT_EQ(memcmp(results[0]->GetData()->Data(), buffer1->Data(), buffer1->Size()), 0);
     ASSERT_EQ(memcmp(results[0]->GetData()->Data() + buffer1->Size(), buffer2->Data(),
                      buffer2->Size()),
-              0);
+              0);             
   }
 }
 

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -188,10 +188,9 @@ bool CoreWorkerDirectActorTaskSubmitter::IsActorAlive(const ActorID &actor_id) c
 }
 
 CoreWorkerDirectActorTaskReceiver::CoreWorkerDirectActorTaskReceiver(
-    CoreWorkerObjectInterface &object_interface, boost::asio::io_service &io_service,
+    boost::asio::io_service &io_service,
     rpc::GrpcServer &server, const TaskHandler &task_handler)
-    : object_interface_(object_interface),
-      task_service_(io_service, *this),
+    : task_service_(io_service, *this),
       task_handler_(task_handler) {
   server.RegisterService(task_service_);
 }

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -51,6 +51,7 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(
     // to have a timeout to mark it as invalid if it doesn't show up in the
     // specified time.
     pending_requests_[actor_id].emplace_back(std::move(request));
+    pending_tasks_[actor_id].insert(std::make_pair(task_id, num_returns));
     return Status::OK();
   } else if (iter->second.state_ == ActorTableData::ALIVE) {
     // Actor is alive, submit the request.
@@ -62,7 +63,7 @@ Status CoreWorkerDirectActorTaskSubmitter::SubmitTask(
 
     // Submit request.
     auto &client = rpc_clients_[actor_id];
-    PushTask(*client, *request, task_id, num_returns);
+    PushTask(*client, *request, actor_id, task_id, num_returns);
     return Status::OK();
   } else {
     // Actor is dead, treat the task as failure.
@@ -103,6 +104,19 @@ Status CoreWorkerDirectActorTaskSubmitter::SubscribeActorUpdates() {
         }
         pending_requests_.erase(actor_id);
       }
+
+      // For tasks that have been sent and are waiting for replies, treat them
+      // as failed when the destination actor is dead or reconstructing.
+      auto iter = waiting_reply_tasks_.find(actor_id);
+      if (iter != waiting_reply_tasks_.end()) {
+        for (const auto &entry : iter->second) {
+          const auto &task_id = entry.first;
+          const auto num_returns = entry.second;
+          TreatTaskAsFailed(task_id, num_returns, rpc::ErrorType::ACTOR_DIED);
+        }
+        waiting_reply_tasks_.erase(actor_id);
+      }
+
     }
 
     RAY_LOG(INFO) << "received notification on actor, state="
@@ -125,19 +139,32 @@ void CoreWorkerDirectActorTaskSubmitter::ConnectAndSendPendingTasks(
   auto &requests = pending_requests_[actor_id];
   while (!requests.empty()) {
     const auto &request = *requests.front();
-    PushTask(*client, request, TaskID::FromBinary(request.task_spec().task_id()),
+    PushTask(*client, request, actor_id, TaskID::FromBinary(request.task_spec().task_id()),
              request.task_spec().num_returns());
     requests.pop_front();
   }
+
+  pending_tasks_.erase(actor_id);
 }
 
 void CoreWorkerDirectActorTaskSubmitter::PushTask(rpc::DirectActorClient &client,
                                                   const rpc::PushTaskRequest &request,
+                                                  const ActorID &actor_id,
                                                   const TaskID &task_id,
                                                   int num_returns) {
+  if (num_returns > 1) {
+    waiting_reply_tasks_[actor_id].insert(std::make_pair(task_id, num_returns));
+  }                                                   
   auto status = client.PushTask(
       request,
-      [this, task_id, num_returns](Status status, const rpc::PushTaskReply &reply) {
+      [this, actor_id, task_id, num_returns](Status status, const rpc::PushTaskReply &reply) {
+        {
+          std::unique_lock<std::mutex> guard(mutex_);
+          if (num_returns > 1) {
+            waiting_reply_tasks_[actor_id].erase(task_id);
+          }
+        }        
+        
         if (!status.ok()) {
           TreatTaskAsFailed(task_id, num_returns, rpc::ErrorType::ACTOR_DIED);
           return;
@@ -186,6 +213,108 @@ bool CoreWorkerDirectActorTaskSubmitter::IsActorAlive(const ActorID &actor_id) c
   auto iter = actor_states_.find(actor_id);
   return (iter != actor_states_.end() && iter->second.state_ == ActorTableData::ALIVE);
 }
+
+bool CoreWorkerDirectActorTaskSubmitter::ShouldWaitObjects(
+    const std::vector<ObjectID> &object_ids) {
+  for (const auto &object_id : object_ids) {
+    bool task_finished = IsTaskFinished(object_id.TaskId());
+    if (!task_finished) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool CoreWorkerDirectActorTaskSubmitter::IsTaskFinished(const TaskID &task_id) const {
+  std::unique_lock<std::mutex> guard(mutex_);
+  auto actor_id = task_id.ActorId();
+  auto iter = pending_tasks_.find(actor_id);
+  if (iter != pending_tasks_.end() && iter->second.count(task_id) > 0) {
+    return false;
+  }
+
+  iter = waiting_reply_tasks_.find(actor_id);
+  if (iter != waiting_reply_tasks_.end() && iter->second.count(task_id) > 0) {
+    return false;
+  }
+
+  return true;
+}
+
+Status CoreWorkerDirectActorTaskSubmitter::GetReturnObjects(
+    const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
+    const TaskID &task_id,
+    std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results) {
+  if (object_ids.empty()) {
+    return Status::OK();
+  }
+
+  std::unordered_set<ObjectID> unready(object_ids);
+
+  int num_attempts = 0;
+  bool should_break = false;
+  int64_t remaining_timeout = timeout_ms;
+  // Repeat until we get all objects.
+  while (!unready.empty() && !should_break) {
+    std::vector<ObjectID> unready_ids;
+    for (const auto &entry : unready) {
+      unready_ids.push_back(entry);
+    }
+
+    // Check whether we should wait for objects to be created/reconstructed,
+    // or just fetch from store.
+    bool should_wait = ShouldWaitObjects(unready_ids);
+
+    // Get the objects from the object store, and parse the result.
+    int64_t get_timeout = RayConfig::instance().get_timeout_milliseconds();
+    if (!should_wait) {
+      get_timeout = 0;
+      remaining_timeout = 0;
+      should_break = true;
+    } else if (remaining_timeout >= 0) {
+      get_timeout = std::min(remaining_timeout, get_timeout);
+      remaining_timeout -= get_timeout;
+      should_break = remaining_timeout <= 0;
+    }
+
+    std::vector<std::shared_ptr<RayObject>> result_objects;
+    RAY_RETURN_NOT_OK(
+        store_provider_->Get(unready_ids, get_timeout, task_id, &result_objects));
+
+    for (size_t i = 0; i < result_objects.size(); i++) {
+      if (result_objects[i] != nullptr) {
+        const auto &object_id = unready_ids[i];
+        (*results).emplace(object_id, result_objects[i]);
+        unready.erase(object_id);
+        if (result_objects[i]->IsException()) {
+          should_break = true;
+        }
+      }
+    }
+
+    num_attempts += 1;
+    CoreWorkerStoreProvider::WarnIfAttemptedTooManyTimes(num_attempts, unready);
+
+    if (!should_wait && !unready.empty()) {
+      // If the tasks that created these objects have already finished, but we are still
+      // not able to get some of the objects from store, it's likely that these objects
+      // have been evicted from store, so them as unreconstructable.
+      std::string meta =
+          std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE));
+      auto metadata =
+          const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(meta.data()));
+      auto meta_buffer = std::make_shared<LocalMemoryBuffer>(metadata, meta.size(), true);
+      auto object = std::make_shared<RayObject>(nullptr, meta_buffer);
+      for (const auto &entry : unready) {
+        (*results).emplace(entry, object);
+      }
+    }
+  }
+
+  return Status::OK();
+}
+
 
 CoreWorkerDirectActorTaskReceiver::CoreWorkerDirectActorTaskReceiver(
     boost::asio::io_service &io_service,

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -38,6 +38,18 @@ class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
   /// \return Status.
   Status SubmitTask(const TaskSpecification &task_spec) override;
 
+  /// Get a list of return objects for tasks submitted from this transport.
+  ///
+  /// \param[in] object_ids IDs of the objects to get.
+  /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's -1.
+  /// \param[in] task_id ID for the current task.
+  /// \param[out] results Result list of objects data.
+  /// \return Status.
+  Status GetReturnObjects(
+    const std::unordered_set<ObjectID> &object_ids, int64_t timeout_ms,
+    const TaskID &task_id,
+    std::unordered_map<ObjectID, std::shared_ptr<RayObject>> *results);
+
  private:
   /// Subscribe to all actor updates.
   Status SubscribeActorUpdates();
@@ -52,7 +64,7 @@ class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
   /// \param[in] num_returns Number of return objects.
   /// \return Void.
   void PushTask(rpc::DirectActorClient &client, const rpc::PushTaskRequest &request,
-                const TaskID &task_id, int num_returns);
+                const ActorID &actor_id, const TaskID &task_id, int num_returns);
 
   /// Treat a task as failed.
   ///
@@ -79,6 +91,18 @@ class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
   /// \param[in] actor_id The actor ID.
   /// \return Whether this actor is alive.
   bool IsActorAlive(const ActorID &actor_id) const;
+
+  /// Helper function to check whether to wait for a list of objects to appear,
+  /// e.g. wait for the tasks which create these objects to finish.
+  ///
+  /// \param[in] object_ids A list of object ids.
+  bool ShouldWaitObjects(const std::vector<ObjectID> &object_ids);
+
+  /// Return if the task is finished.
+  ///
+  /// \param[in] task_id The ID of the task.
+  /// \return Whether the task is finished.
+  bool IsTaskFinished(const TaskID &task_id) const;
 
   /// The IO event loop.
   boost::asio::io_service &io_service_;
@@ -109,6 +133,11 @@ class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
   /// Map from actor id to the actor's pending requests.
   std::unordered_map<ActorID, std::list<std::unique_ptr<rpc::PushTaskRequest>>>
       pending_requests_;
+
+  /// Map from actor id to the tasks that are pending to send out.
+  std::unordered_map<ActorID, std::unordered_map<TaskID, int>> pending_tasks_;
+  /// Map from actor id to the tasks that are waiting for reply.
+  std::unordered_map<ActorID, std::unordered_map<TaskID, int>> waiting_reply_tasks_;
 
   /// The store provider.
   std::unique_ptr<CoreWorkerStoreProvider> store_provider_;

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -119,8 +119,7 @@ class CoreWorkerDirectActorTaskSubmitter : public CoreWorkerTaskSubmitter {
 class CoreWorkerDirectActorTaskReceiver : public CoreWorkerTaskReceiver,
                                           public rpc::DirectActorHandler {
  public:
-  CoreWorkerDirectActorTaskReceiver(CoreWorkerObjectInterface &object_interface,
-                                    boost::asio::io_service &io_service,
+  CoreWorkerDirectActorTaskReceiver(boost::asio::io_service &io_service,
                                     rpc::GrpcServer &server,
                                     const TaskHandler &task_handler);
 
@@ -135,8 +134,6 @@ class CoreWorkerDirectActorTaskReceiver : public CoreWorkerTaskReceiver,
                       rpc::SendReplyCallback send_reply_callback) override;
 
  private:
-  // Object interface.
-  CoreWorkerObjectInterface &object_interface_;
   /// The rpc service for `DirectActorService`.
   rpc::DirectActorGrpcService task_service_;
   /// The callback function to process a task.

--- a/src/ray/core_worker/transport/raylet_transport.h
+++ b/src/ray/core_worker/transport/raylet_transport.h
@@ -33,7 +33,7 @@ class CoreWorkerRayletTaskReceiver : public CoreWorkerTaskReceiver,
                                      public rpc::WorkerTaskHandler {
  public:
   CoreWorkerRayletTaskReceiver(std::unique_ptr<RayletClient> &raylet_client,
-                               CoreWorkerObjectInterface &object_interface,
+                               CoreWorkerStoreProviderMap &store_providers,
                                boost::asio::io_service &io_service,
                                rpc::GrpcServer &server, const TaskHandler &task_handler);
 
@@ -52,7 +52,7 @@ class CoreWorkerRayletTaskReceiver : public CoreWorkerTaskReceiver,
   /// Raylet client.
   std::unique_ptr<RayletClient> &raylet_client_;
   // Object interface.
-  CoreWorkerObjectInterface &object_interface_;
+  CoreWorkerStoreProviderMap &store_providers_;
   /// The rpc service for `WorkerTaskService`.
   rpc::WorkerTaskGrpcService task_service_;
   /// The callback function to process a task.

--- a/src/ray/core_worker/transport/transport.h
+++ b/src/ray/core_worker/transport/transport.h
@@ -42,6 +42,9 @@ class CoreWorkerTaskReceiver {
   virtual ~CoreWorkerTaskReceiver() {}
 };
 
+using CoreWorkerTaskSubmitterMap =
+    EnumUnorderedMap<TaskTransportType, std::unique_ptr<CoreWorkerTaskSubmitter>>;
+
 }  // namespace ray
 
 #endif  // RAY_CORE_WORKER_TRANSPORT_H


### PR DESCRIPTION
## Why are these changes needed?

NOTE that this currently only handles `Get()`, but not `Wait()`.

## Related issue number


## Linter

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
