### PR TITLE
turn off lineage

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -157,7 +157,7 @@ RAY_CONFIG(size_t, free_objects_batch_size, 100)
 /// the task's recursive dependencies. If this is set to true, then the system
 /// will attempt to reconstruct the object from its lineage if the object is
 /// lost.
-RAY_CONFIG(bool, lineage_pinning_enabled, true)
+RAY_CONFIG(bool, lineage_pinning_enabled, false)
 
 /// Objects that require recovery are added to a local cache. This is the
 /// duration between attempts to flush and recover the objects in the local

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -157,6 +157,12 @@ RAY_CONFIG(size_t, free_objects_batch_size, 100)
 /// the task's recursive dependencies. If this is set to true, then the system
 /// will attempt to reconstruct the object from its lineage if the object is
 /// lost.
+/// We change the default to false because not everyone needs the reconstruction
+/// but 
+/// The lineage mechanism will keep pinning objects and therefore increase the memory
+/// usage (see #22816 https://github.com/ray-project/ray/pull/22816/files), since
+/// not everyone needs the task FO, we change the default to False, more defails
+/// see #381 (https://github.com/alipay/ant-ray/pull/381).
 RAY_CONFIG(bool, lineage_pinning_enabled, false)
 
 /// Objects that require recovery are added to a local cache. This is the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Lineage needs to pin the input objects for the reconstruction,  which increase the memory usage.
The lineage feature is to try to avoid the ObjectLostError and therefore increase the computation stability, however it's still can't fully address the problem but increase the memory usage, so we turn off it by default.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
