### PR TITLE
[TEE] Set a random key to avoid other node joining the cluster.

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -601,6 +601,13 @@ def start(
             stacklevel=2,
         )
 
+    if os.getenv("ENABLE_TEE") == "true":
+        # This is the code path to set a random access key for Redis, to workaround
+        # avoiding other worker nodes joining into this cluster.
+        # Currently, we now only support 1 head node if `ENABLE_TEE` is on.
+        import uuid
+        redis_password = uuid.uuid4()
+
     redirect_output = None if not no_redirect_output else True
     ray_params = ray._private.parameter.RayParams(
         node_ip_address=node_ip_address,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We now support that the HEAD node is in TEE, and we should prevent other nodes joining to this cluster, as a result, give a random password for head node is a simple approach, with a minor change.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
