### PR TITLE
Enable log to driver

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -195,4 +195,4 @@ try-import %workspace%/.llvm-local.bazelrc
 
 # Running Ray inside TEE environment requires special compilation, normally
 # keep this flag to false unless you know what you are doing
-build --define RAY_IN_TEE=true
+build --define RAY_IN_TEE=false

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -785,9 +785,16 @@ def start_ray_process(
             creationflags=CREATE_SUSPENDED if win32_fate_sharing else 0,
         )
     else:
+        # `os.dup2` only takes fd instead of file handler
+        if (stdout_file is not None):
+            if (hasattr(stdout_file, "fileno")):
+                stdout_file = stdout_file.fileno()
+        if (stderr_file is not None):
+            if (hasattr(stderr_file, "fileno")):
+                stderr_file = stderr_file.fileno()
         file_actions = [
-            (os.POSIX_SPAWN_DUP2, stdout_file.fileno(), sys.stdout.fileno()),
-            (os.POSIX_SPAWN_DUP2, stderr_file.fileno(), sys.stderr.fileno()),
+            (os.POSIX_SPAWN_DUP2, stdout_file, sys.stdout.fileno()),
+            (os.POSIX_SPAWN_DUP2, stderr_file, sys.stderr.fileno()),
         ]
         # TODO(NKcqx): Support cwd and pipe_stdin (cwd may never get supported,
         # see issue: https://github.com/python/cpython/issues/79718)

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -786,10 +786,10 @@ def start_ray_process(
         )
     else:
         # `os.dup2` only takes fd instead of file handler
-        if (stdout_file is not None):
+        if stdout_file is not None:
             if (hasattr(stdout_file, "fileno")):
                 stdout_file = stdout_file.fileno()
-        if (stderr_file is not None):
+        if stderr_file is not None:
             if (hasattr(stderr_file, "fileno")):
                 stderr_file = stderr_file.fileno()
         file_actions = [

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -795,7 +795,7 @@ def start_ray_process(
         file_actions = [
             (os.POSIX_SPAWN_DUP2, stdout_file, sys.stdout.fileno()),
             (os.POSIX_SPAWN_DUP2, stderr_file, sys.stderr.fileno()),
-        ]
+        ] if stdout_file >= 0 else None
         # TODO(NKcqx): Support cwd and pipe_stdin (cwd may never get supported,
         # see issue: https://github.com/python/cpython/issues/79718)
         process = os.posix_spawn(

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -786,12 +786,10 @@ def start_ray_process(
         )
     else:
         # `os.dup2` only takes fd instead of file handler
-        if stdout_file is not None:
-            if (hasattr(stdout_file, "fileno")):
-                stdout_file = stdout_file.fileno()
-        if stderr_file is not None:
-            if (hasattr(stderr_file, "fileno")):
-                stderr_file = stderr_file.fileno()
+        if stdout_file is not None and hasattr(stdout_file, "fileno"):
+            stdout_file = stdout_file.fileno()
+        if stderr_file is not None and hasattr(stderr_file, "fileno"):
+            stderr_file = stderr_file.fileno()
         file_actions = [
             (os.POSIX_SPAWN_DUP2, stdout_file, sys.stdout.fileno()),
             (os.POSIX_SPAWN_DUP2, stderr_file, sys.stderr.fileno()),

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -870,6 +870,7 @@ class Node:
 
     def start_log_monitor(self):
         """Start the log monitor."""
+        print(f"====== redirect_logging: {self.should_redirect_logs()} =========")
         process_info = ray._private.services.start_log_monitor(
             self._logs_dir,
             self.gcs_address,
@@ -1140,11 +1141,9 @@ class Node:
             huge_pages=self._ray_params.huge_pages,
         )
         self.start_raylet(plasma_directory, object_store_memory)
-        if not ray_in_tee():
-            # Workaround because these params are not available in ray.init().
-            # Should be reverted once we start Ray with `ray start` CLI.
-            if self._ray_params.include_log_monitor:
-                self.start_log_monitor()
+
+        if self._ray_params.include_log_monitor:
+            self.start_log_monitor()
 
     def _kill_process_type(
         self, process_type, allow_graceful=False, check_alive=True, wait=False

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -870,7 +870,6 @@ class Node:
 
     def start_log_monitor(self):
         """Start the log monitor."""
-        print(f"====== redirect_logging: {self.should_redirect_logs()} =========")
         process_info = ray._private.services.start_log_monitor(
             self._logs_dir,
             self.gcs_address,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The occlum version temporarily close the log monitor, this PR open it.
Besides, the occlum version use `os.posix_spawn` to start new process, however, its file redirection is not as flexible as `subprocess.Popen` such as it only takes positive `int fd` as input but file handler or `subprocess.DEVNULL`( which is "-3"). So this PR makes some conversion.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
