### PR TITLE
Repair `follow_symlinks` bug in old aiohttp version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -36,7 +36,7 @@ urllib3
 tabulate
 scikit-image
 scipy
-aiohttp>=3.7
+aiohttp>=3.9.3
 fastapi
 gym<0.24.1,>=0.21.0
 opencensus


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We use "static" path in aiohttp, however, when `follow_symlinks` is set to true, a path reverse breakdown problem will exist in the static directory file, for example: 
![image](https://github.com/alipay/ant-ray/assets/26196566/ae21c2b4-2ee9-45ae-be51-9ab273287647)

This has been fixed in aiohttp>=3.9.3
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
